### PR TITLE
Fix Queue.Pop locking

### DIFF
--- a/pkg/log/xlog.go
+++ b/pkg/log/xlog.go
@@ -23,12 +23,22 @@ func (q *Queue[T]) Push(x T) {
 }
 
 func (q *Queue[T]) Pop() T {
-	len := len(q.list)
-	var el T
-	q.rwMu.RLock()
-	el, q.list = q.list[0], q.list[1:len]
-	q.rwMu.RUnlock()
-	return el
+       q.rwMu.Lock()
+       length := len(q.list)
+       var el T
+       el, q.list = q.list[0], q.list[1:length]
+       q.rwMu.Unlock()
+       return el
+}
+
+func (q *Queue[T]) Top() T {
+       q.rwMu.RLock()
+       var el T
+       if len(q.list) > 0 {
+               el = q.list[0]
+       }
+       q.rwMu.RUnlock()
+       return el
 }
 
 func (q *Queue[T]) Length() int {


### PR DESCRIPTION
## Summary
- protect Queue slice with a write lock when popping
- read slice length under lock to avoid races
- add `Top` method to access the first element without removing it

## Testing
- `go vet ./...` *(fails: package not in std)*
- `go build ./...` *(fails: package not in std)*
- `go test ./...` *(fails: package not in std)*

------
https://chatgpt.com/codex/tasks/task_e_684b994e2fe48325b8ad6b01f20f5914